### PR TITLE
Added External Access to Object Detection Parameters

### DIFF
--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -67,7 +67,6 @@ def __detect_objects(interpreter, image, threshold):
       results.append(result)
       #global object_detection_list_parameter
   cloneListIntoList(results,object_detection_list_parameter)
-  object_detection_list_parameter = results.copy()
   return results
 
 

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -22,6 +22,19 @@ CAMERA_HEIGHT = 480
 default_model = '/opt/vilib/detect.tflite'
 default_labels = '/opt/vilib/coco_labels.txt'
 
+#######################################################
+object_detection_list_parameter = []
+
+def get_object_dictionary(name="unknown",acc=0):
+  return {
+    "name": name,
+    "acc": acc,
+    # corners,
+    # position,
+    # anything else,
+  }
+#######################################################
+
 def set_input_tensor(interpreter, image):
   """Sets the input tensor."""
   tensor_index = interpreter.get_input_details()[0]['index']

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -60,6 +60,8 @@ def __detect_objects(interpreter, image, threshold):
           'score': scores[i]
       }
       results.append(result)
+      object_detection_list_parameter = results
+      object_detection_list_parameter.append("FLAG1")
   return results
 
 
@@ -115,6 +117,8 @@ def detect_objects(image, model=None, labels=None, width=CAMERA_WIDTH, height=CA
     img = cv2.resize(image, (input_width, input_height))
     # classify
     results = __detect_objects(interpreter, img, threshold)
+    object_detection_list_parameter = results
+    object_detection_list_parameter.append("FLAG2")
     # putText
     image = put_text(image, results, labels, width, height)
     
@@ -217,6 +221,7 @@ def main():
       elapsed_ms = (time.monotonic() - start_time) * 1000
       # print(results)
       object_detection_list_parameter = results
+      object_detection_list_parameter.append("FLAG3")
 
     if run_flag == False:
       print('\nend...')

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -24,6 +24,11 @@ default_labels = '/opt/vilib/coco_labels.txt'
 
 #######################################################
 object_detection_list_parameter = ["Test_a","Test_b"]
+
+def cloneListIntoList(source,destination):
+  destination.clear()
+  for i in source:
+    destination.append(i)
 #######################################################
 
 def set_input_tensor(interpreter, image):
@@ -60,10 +65,9 @@ def __detect_objects(interpreter, image, threshold):
           'score': scores[i]
       }
       results.append(result)
-      global object_detection_list_parameter
-      object_detection_list_parameter = results.copy()
-      object_detection_list_parameter.append("FLAG1")
-      print("TRUE LEN:",len(object_detection_list_parameter))
+      #global object_detection_list_parameter
+  cloneListIntoList(results,object_detection_list_parameter)
+  object_detection_list_parameter = results.copy()
   return results
 
 

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -63,7 +63,7 @@ def __detect_objects(interpreter, image, threshold):
       global object_detection_list_parameter
       object_detection_list_parameter = results.copy()
       object_detection_list_parameter.append("FLAG1")
-      print("A THING HAPPENED")
+      print("TRUE LEN:",len(object_detection_list_parameter))
   return results
 
 
@@ -119,9 +119,6 @@ def detect_objects(image, model=None, labels=None, width=CAMERA_WIDTH, height=CA
     img = cv2.resize(image, (input_width, input_height))
     # classify
     results = __detect_objects(interpreter, img, threshold)
-    global object_detection_list_parameter
-    object_detection_list_parameter = results.copy()
-    object_detection_list_parameter.append("FLAG2")
     # putText
     image = put_text(image, results, labels, width, height)
     
@@ -223,9 +220,6 @@ def main():
       results = __detect_objects(interpreter, image,args.threshold)
       elapsed_ms = (time.monotonic() - start_time) * 1000
       # print(results)
-      global object_detection_list_parameter
-      object_detection_list_parameter = results.copy()
-      object_detection_list_parameter.append("FLAG3")
 
     if run_flag == False:
       print('\nend...')

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -23,7 +23,7 @@ default_model = '/opt/vilib/detect.tflite'
 default_labels = '/opt/vilib/coco_labels.txt'
 
 #######################################################
-object_detection_list_parameter = ["Test_a","Test_b"]
+object_detection_list_parameter = []
 
 def cloneListIntoList(source,destination):
   destination.clear()

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -25,7 +25,12 @@ default_labels = '/opt/vilib/coco_labels.txt'
 #######################################################
 object_detection_list_parameter = []
 
-def cloneListIntoList(source,destination):
+def add_class_names(objects):
+  labels = load_labels(default_labels)
+  for object in objects:
+    object["class_name"] = labels[object['class_id']]
+
+def copy_list_into_list(source,destination):
   destination.clear()
   for i in source:
     destination.append(i)
@@ -66,7 +71,9 @@ def __detect_objects(interpreter, image, threshold):
       }
       results.append(result)
       #global object_detection_list_parameter
-  cloneListIntoList(results,object_detection_list_parameter)
+  # Allow programmer to access the results
+  copy_list_into_list(results,object_detection_list_parameter)
+  add_class_names(object_detection_list_parameter)
   return results
 
 

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -23,7 +23,7 @@ default_model = '/opt/vilib/detect.tflite'
 default_labels = '/opt/vilib/coco_labels.txt'
 
 #######################################################
-object_detection_list_parameter = []
+object_detection_list_parameter = ["Test_a","Test_b"]
 #######################################################
 
 def set_input_tensor(interpreter, image):
@@ -60,8 +60,10 @@ def __detect_objects(interpreter, image, threshold):
           'score': scores[i]
       }
       results.append(result)
+      global object_detection_list_parameter
       object_detection_list_parameter = results.copy()
       object_detection_list_parameter.append("FLAG1")
+      print("A THING HAPPENED")
   return results
 
 
@@ -117,6 +119,7 @@ def detect_objects(image, model=None, labels=None, width=CAMERA_WIDTH, height=CA
     img = cv2.resize(image, (input_width, input_height))
     # classify
     results = __detect_objects(interpreter, img, threshold)
+    global object_detection_list_parameter
     object_detection_list_parameter = results.copy()
     object_detection_list_parameter.append("FLAG2")
     # putText
@@ -220,6 +223,7 @@ def main():
       results = __detect_objects(interpreter, image,args.threshold)
       elapsed_ms = (time.monotonic() - start_time) * 1000
       # print(results)
+      global object_detection_list_parameter
       object_detection_list_parameter = results.copy()
       object_detection_list_parameter.append("FLAG3")
 

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -60,7 +60,7 @@ def __detect_objects(interpreter, image, threshold):
           'score': scores[i]
       }
       results.append(result)
-      object_detection_list_parameter = results
+      object_detection_list_parameter = results.copy()
       object_detection_list_parameter.append("FLAG1")
   return results
 
@@ -117,7 +117,7 @@ def detect_objects(image, model=None, labels=None, width=CAMERA_WIDTH, height=CA
     img = cv2.resize(image, (input_width, input_height))
     # classify
     results = __detect_objects(interpreter, img, threshold)
-    object_detection_list_parameter = results
+    object_detection_list_parameter = results.copy()
     object_detection_list_parameter.append("FLAG2")
     # putText
     image = put_text(image, results, labels, width, height)
@@ -220,7 +220,7 @@ def main():
       results = __detect_objects(interpreter, image,args.threshold)
       elapsed_ms = (time.monotonic() - start_time) * 1000
       # print(results)
-      object_detection_list_parameter = results
+      object_detection_list_parameter = results.copy()
       object_detection_list_parameter.append("FLAG3")
 
     if run_flag == False:

--- a/vilib/objects_detection.py
+++ b/vilib/objects_detection.py
@@ -24,15 +24,6 @@ default_labels = '/opt/vilib/coco_labels.txt'
 
 #######################################################
 object_detection_list_parameter = []
-
-def get_object_dictionary(name="unknown",acc=0):
-  return {
-    "name": name,
-    "acc": acc,
-    # corners,
-    # position,
-    # anything else,
-  }
 #######################################################
 
 def set_input_tensor(interpreter, image):
@@ -225,6 +216,7 @@ def main():
       results = __detect_objects(interpreter, image,args.threshold)
       elapsed_ms = (time.monotonic() - start_time) * 1000
       # print(results)
+      object_detection_list_parameter = results
 
     if run_flag == False:
       print('\nend...')

--- a/vilib/vilib.py
+++ b/vilib/vilib.py
@@ -730,6 +730,8 @@ class Vilib(object):
     @staticmethod
     def object_detect_switch(flag=False):
         Vilib.objects_detect_sw = flag
+        from .objects_detection import object_detection_list_parameter
+        Vilib.object_detection_list_parameter = object_detection_list_parameter
 
     @staticmethod
     def object_detect_set_model(path):


### PR DESCRIPTION
In the standard Vilib library, programmers can access the parameters for modules such as image classification and traffic sign detection. In other words, a programmer can directly access the name and confidence scores of the classification decisions made in those models. However, for the **object detection** module (which not only classifies objects, but determines their locations within an image), this feature is missing. This means that a programmer cannot interact with a list of detected objects, but can only view them visually through a web stream.

My changes extend the Vilib library to enable programmers to access an array of detected objects when using the built-in object detection features. This is very useful for any projects that involve analyzing or communicating the object detection data. For example, I am using Vilib for an edge computing project that requires multiple agents to communicate with each other through an edge server, which would not be possible without having access to the actual output parameters.

To use this added feature, first import Vilib and enable the object detection features:
`from vilib import Vilib`
`Vilib.camera_start(vflip=False, hflip=False)`
`Vilib.show_fps()`
`Vilib.display(local=True, web=True)`
`Vilib.object_detect_switch(True)`

Then, you may freely access the object detection list parameter from your Python code e.g.:
`print(Vilib.object_detection_list_parameter)`

This will display a list of each of the detected objects and their Class names / accuracy scores. The format is a list of dictionaries (objects). Each object has the following attributes:

- **bounding_box (array)**, I am not sure exactly how this data is formatted but it contains 4 float32 values that each presumably correspond to one edge of the bounding box surrounding the object.
- **class_id (float)**, Unique ID corresponding to each object
- **score (float)**, Accuracy/confidence of the classification algorithm
- **class_name (string)**, The string-formatted name of the object that the algorithm thinks it sees. For example, class_id=66 --> class_name="dining table". This is based on the COCO dataset.

Example output can be found below:

![example_vilib_output](https://github.com/sunfounder/vilib/assets/48892943/c194fa33-6542-4d3e-976b-48a2345e66c0)