### PR TITLE
Allow Programmer Access to Complete List of Detected QR Codes

### DIFF
--- a/examples/qr_coder_read.py
+++ b/examples/qr_coder_read.py
@@ -21,8 +21,11 @@ def main():
     sleep(1)
 
     while True:
-        text = Vilib.detect_obj_parameter['qr_data'] 
-        print(text)
+        texts = [x['text'] for x in Vilib.detect_obj_parameter['qr_list']]
+        if len(texts)>0:
+            print(", ".join(texts))
+        else:
+            print("None")
         sleep(0.5)  
 
 

--- a/vilib/qrcode_recognition.py
+++ b/vilib/qrcode_recognition.py
@@ -8,11 +8,14 @@ qrcode_obj_parameter['y'] = 0   # the largest block center y-axis coordinate
 qrcode_obj_parameter['w'] = 0     # the largest block pixel width
 qrcode_obj_parameter['h'] = 0     # the largest block pixel height
 qrcode_obj_parameter['data'] = "None" # recognition result
+qrcode_obj_parameter['list'] = []
 
 
 def qrcode_recognize(img, border_rgb=(255, 0, 0)):
     # Detect and decode QR codes
     barcodes = pyzbar.decode(img)
+
+    qrcode_obj_parameter['list'].clear()
 
     if len(barcodes) > 0:
         for barcode in barcodes:
@@ -24,6 +27,15 @@ def qrcode_recognize(img, border_rgb=(255, 0, 0)):
             barcodeData = barcode.data.decode("utf-8")
             # barcodeType = barcode.type
             text = f"{barcodeData}"
+
+            # add the barcode to the list of barcodes for output
+            qrcode_obj_parameter['list'].append({
+                'text': text,
+                'x': x,
+                'y': y,
+                'w': w,
+                'h': h,
+            })
 
             if len(text) > 0:
                 qrcode_obj_parameter['data'] = text

--- a/vilib/vilib.py
+++ b/vilib/vilib.py
@@ -594,6 +594,7 @@ class Vilib(object):
             Vilib.detect_obj_parameter['qr_w'] = Vilib.qrcode_obj_parameter['w']
             Vilib.detect_obj_parameter['qr_h'] = Vilib.qrcode_obj_parameter['h']
             Vilib.detect_obj_parameter['qr_data'] = Vilib.qrcode_obj_parameter['data']
+            Vilib.detect_obj_parameter['qr_list'] = Vilib.qrcode_obj_parameter['qr_list']
 
     @staticmethod
     def qrcode_detect_func(img):

--- a/vilib/vilib.py
+++ b/vilib/vilib.py
@@ -594,7 +594,7 @@ class Vilib(object):
             Vilib.detect_obj_parameter['qr_w'] = Vilib.qrcode_obj_parameter['w']
             Vilib.detect_obj_parameter['qr_h'] = Vilib.qrcode_obj_parameter['h']
             Vilib.detect_obj_parameter['qr_data'] = Vilib.qrcode_obj_parameter['data']
-            Vilib.detect_obj_parameter['qr_list'] = Vilib.qrcode_obj_parameter['qr_list']
+            Vilib.detect_obj_parameter['qr_list'] = Vilib.qrcode_obj_parameter['list']
 
     @staticmethod
     def qrcode_detect_func(img):


### PR DESCRIPTION
The current Vilib QR Code reader only allows the programmer to view the data of one QR code at a time. For example, if there are three QR codes in front of the camera, all 3 will be visually displayed on the Flask rendering, but the position/size/text of only one will be accessible through parameters such as `Vilib.detect_obj_parameter['qr_data']`.

Therefore, I have modified the source code to give the programmer access to all of the detected QR codes, including the text content, position, and size parameters. You can access this data with `Vilib.detect_obj_parameter['qr_list']`, which is a List of Dictionaries containing attributes `text`, `x`, `y`, `w`, and `h`, taken directly from the underlying computer vision code.

I also modified the corresponding example code, `vilib/examples/qr_coder_read.py`, which will now print the names of each detected QR code (if more than one exist), instead of always just one. The behavior will work exactly the same when there is only one detected QR code.

I have tested my code using multiple printed QR codes, and it all works as expected with no errors.